### PR TITLE
Update AbstractClientPlayerEntityMixin.java

### DIFF
--- a/src/main/java/net/kaupenjoe/tutorialmod/mixin/AbstractClientPlayerEntityMixin.java
+++ b/src/main/java/net/kaupenjoe/tutorialmod/mixin/AbstractClientPlayerEntityMixin.java
@@ -16,24 +16,10 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-// With help from https://github.com/Globox1997/MedievalWeapons/blob/1.21/src/main/java/net/medievalweapons/mixin/client/AbstractClientPlayerEntityMixin.java
-// Under MIT License!
 @Mixin(AbstractClientPlayerEntity.class)
-public abstract class AbstractClientPlayerEntityMixin extends PlayerEntity {
-    public AbstractClientPlayerEntityMixin(World world, BlockPos pos, float yaw, GameProfile gameProfile) {
-        super(world, pos, yaw, gameProfile);
-    }
-
-    @Inject(method = "getFovMultiplier", at = @At(value = "TAIL"), locals = LocalCapture.CAPTURE_FAILSOFT, cancellable = true)
-    private void getFovMultiplierMixin(CallbackInfoReturnable<Float> info, float f) {
-        Item item = this.getActiveItem().getItem();
-        ItemStack itemStack = this.getActiveItem();
-        if (this.isUsingItem() && itemStack.isOf(ModItems.KAUPEN_BOW)) {
-            int i = this.getItemUseTime();
-            float g = (float)i / 20.0f;
-            g = g > 1.0f ? 1.0f : g * g;
-            f *= 1.0f - g * 0.15f;
-            info.setReturnValue(MathHelper.lerp(MinecraftClient.getInstance().options.getFovEffectScale().getValue().floatValue(), 1.0f, f));
-        }
+public abstract class AbstractClientPlayerEntityMixin {
+    @WrapOperation(method = "getFovMultiplier", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isOf(Lnet/minecraft/item/Item;)Z"))
+    public boolean customBowFovMultipliers(ItemStack instance, Item item, Operation<Boolean> original) {
+        return original.call(instance, item) || instance.isOf(ModItems.KAUPEN_BOW);
     }
 }


### PR DESCRIPTION
In your bow tutorial video, you used a mixin with an @Inject to add zoom to your custom bow. I think that it is much better to use @WrapOperation from MixinExtras in this case instead of @Inject, and it is also much simpler. Also it is a bad practice to extend mixin classes so also don't do that. If you want to refer to the current instance you should use an ((Object) this) cast and then an instanceof check.